### PR TITLE
Enable multi-account testing without rebuilding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ tmp/
 temp/
 *.tmp
 
+# Multi-account testing data
+.dev-data/
+
 # Package manager
 package-lock.json
 yarn.lock

--- a/package.json
+++ b/package.json
@@ -1,11 +1,13 @@
 {
   "name": "scribecat-v2",
-  "version": "1.51.0",
+  "version": "1.51.1",
   "type": "module",
   "description": "ScribeCat scribes and is cat. A revolutionary multi-platform app that can be used to record and accurately transcribe speech, take rich text notes, and interact with AI to better understand the content of the recording and your notes.",
   "main": "dist/main/main.js",
   "scripts": {
     "dev": "npm run compile && concurrently -k -n \"MAIN,PRELOAD,RENDERER,ELECTRON\" -c \"cyan,magenta,green,yellow\" \"node build-main.js --watch\" \"node build-preload.js --watch\" \"node build-renderer.js --watch\" \"electron .\"",
+    "dev:account1": "electron . --user-data-dir=./.dev-data/account1",
+    "dev:account2": "electron . --user-data-dir=./.dev-data/account2",
     "compile": "node build-main.js && tsc -p tsconfig.preload.json && node build-renderer.js",
     "build": "npm run compile && electron-builder",
     "build:mac": "npm run compile && electron-builder --mac",


### PR DESCRIPTION
- Add dev:account1 and dev:account2 npm scripts for parallel testing
- Use --user-data-dir to isolate user sessions, auth, and storage
- Add .dev-data/ to .gitignore for test account data
- Enables testing friends presence feature without rebuilding

🤖 Generated with [Claude Code](https://claude.com/claude-code)